### PR TITLE
Enable pickling and unpickling of Cards.

### DIFF
--- a/eval7/cards.pyx
+++ b/eval7/cards.pyx
@@ -20,7 +20,15 @@ cdef class Card:
         cards = map(Card, ('As', '4d', '4c', '3s', '2d'))
         eval7.evaluate(cards)
     """
-    def __cinit__(self, card_string):
+
+    def __cinit__(self, card_string=None):
+        if card_string is not None:
+            self.__setstate__(card_string)
+
+    def __getstate__(self):
+        return self.__str__()
+
+    def __setstate__(self, card_string):
         rank = ranks.index(card_string[0])
         suit = suits.index(card_string[1])
         self.mask = (<unsigned long long>1) << (13 * suit + rank)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extensions = cythonize('eval7/*.pyx')
 
 setup(
     name='eval7',
-    version='0.1.8',
+    version='0.1.9',
     description='A poker hand evaluation and equity calculation library',
     long_description=long_description,
     long_description_content_type='text/x-rst',

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -6,6 +6,7 @@
 import unittest
 
 import eval7
+import pickle
 
 class TestCards(unittest.TestCase):
     def test_suits(self):
@@ -19,3 +20,11 @@ class TestCards(unittest.TestCase):
             for suit in eval7.suits:
                 card = eval7.Card(rank + suit)
                 self.assertEqual(card.rank, i)
+
+    def test_pickle(self):
+        for i, rank in enumerate(eval7.ranks):
+            for suit in eval7.suits:
+                card = eval7.Card(rank + suit)
+                pickled = pickle.dumps(card)
+                card2 = pickle.loads(pickled)
+                self.assertEqual(card, card2)


### PR DESCRIPTION
Hi - my usecase benefits from being able to pickle and unpickle cards. Implemented the necessary __getstate__ and __setstate__ methods, and a simple test case. 

The portable format is ASCII - which should be quite compact and still readable. 

I don't think that has major performance impacts to consider - however, it required the __cinit__ to accept no parameters - which could break some safety guarantees. 