### PR TITLE
Makes imports absolute to be compatible with Python 3.12

### DIFF
--- a/eval7/equity.pyx
+++ b/eval7/equity.pyx
@@ -3,10 +3,9 @@
 # This software may be modified and distributed under the terms
 # of the MIT license.  See the LICENSE file for details.
 
-import cython
-from xorshift_rand cimport randint
-from evaluate cimport cy_evaluate
-from cards cimport cards_to_mask
+from .xorshift_rand cimport randint
+from .evaluate cimport cy_evaluate
+from .cards cimport cards_to_mask
 
 
 cdef extern from "stdlib.h":

--- a/eval7/evaluate.pyx
+++ b/eval7/evaluate.pyx
@@ -3,8 +3,7 @@
 # This software may be modified and distributed under the terms
 # of the MIT license.  See the LICENSE file for details.
 
-import cython
-from cards cimport cards_to_mask
+from .cards cimport cards_to_mask
 
 
 cdef extern from "arrays.h":


### PR DESCRIPTION
The current version does not work with python>3.10 and cypthon>=1. Making the  import paths absolute fixes this.