### PR TITLE
Fix Cython dependency missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
     keywords='poker equity library',
     packages=['eval7'],
     ext_modules=extensions,
-    install_requires=['pyparsing', 'future'],
+    install_requires=['pyparsing', 'future', 'Cython'],
 )


### PR DESCRIPTION
When I wanted to use `pyeval17`, I faced the problem of missing `Cython`. Moreover, if you install `Cython` separately, a dependency conflict occurs.

Please add `Cython` to `setup.py`.