### PR TITLE
Add pyproject.toml so Cython is installed before setup.py runs (fixes install on 3.13/3.14)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61", "wheel", "Cython>=3.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Installing eval7 on Python 3.13 or 3.14 currently fails. There are no wheels past cp312, so pip falls back to the sdist, and the build dies before it starts:

```
ModuleNotFoundError: No module named 'Cython'
ERROR: Failed to build 'eval7' when getting requirements to build wheel
```

The cause is that `setup.py` imports Cython at module scope (line 3), but there is no `pyproject.toml`. Under PEP 517, pip builds in an isolated environment containing only setuptools and wheel, so Cython is missing at the moment `setup.py` is first imported — before anything in it can take effect. Installing Cython into the outer environment doesn't help either, because the isolated build env doesn't inherit from it.

This adds a `[build-system]` table declaring Cython as a build requirement, which is the mechanism PEP 518 provides for exactly this. pip then installs Cython into the build env before importing `setup.py`, and the build proceeds normally. `setup.py` is unchanged.

### Why #19 didn't work

#19 added Cython to `install_requires`, which is the runtime dependency list — it isn't consulted until after `setup()` has already run, so `setup.py` still fails at import time. Your read that it didn't work was correct. `[build-system] requires` is the build-time equivalent, and it's the field that governs what exists when `setup.py` is imported.

### On removing the Cython step

You mentioned in #19 that you'd like to remove the Cython installation step. This doesn't do that, and I'd gently argue against it. The usual way to drop the build-time Cython dependency is to ship pre-generated `.c` files in the sdist. But Cython-generated C uses CPython internals, and C generated by an older Cython routinely fails to compile against newer CPython headers — a common reason projects break on each new release.

If 0.1.10 had shipped `.c` generated in 2024, it would likely fail on 3.14 regardless, and fixing it would mean regenerating anyway. Keeping Cython in the build is what let a current Cython 3.x absorb the 3.14-specific glue and produce a working extension from the existing `.pyx` sources with no changes. From a user's point of view the manual step does disappear — `pip install eval7` just works, and they never install Cython themselves.

### Verification

Built and tested against `python:3.14-slim`, from a clean checkout of master with only this file added:

- **Builds**: produces `eval7-0.1.10-cp314-cp314-linux_x86_64.whl`. No source changes needed.
- **Tests**: 18 passed. The only output is `PyparsingDeprecationWarning` for `delimitedList`/`parseString` from newer pyparsing, unrelated to this change.
- **Correctness**: I compared the resulting extension against the official cp312 wheel from PyPI across **all 2,598,960 distinct 5-card hands**, hashing the full `(cards -> rank)` table on each. The digests are identical:

```
cp312 wheel (PyPI)  5e41c11e04c8357bcb732d3c32908c932bc2a81c3f9b1a77724b954b0bccd9db
cp314 (this build)  5e41c11e04c8357bcb732d3c32908c932bc2a81c3f9b1a77724b954b0bccd9db
```

Also identical across 200,000 random 7-card hands, covering all nine hand types. So the rebuilt extension is behaviourally indistinguishable from the wheel you ship today.

The `setuptools>=61` floor is conservative and could be dropped; `Cython>=3.0` is the part that matters, since Cython 3.x is what knows how to target 3.13/3.14.

Happy to adjust anything here. Thanks for maintaining this — the exhaustive check above was easy to run precisely because the evaluator is fast.